### PR TITLE
Added weights to rainbow training

### DIFF
--- a/core/logic.py
+++ b/core/logic.py
@@ -89,16 +89,19 @@ def training_score(x):
 
 # Do rainbow training
 def rainbow_training(results):
+  global PRIORITY_WEIGHTS_LIST
+  priority_weight = PRIORITY_WEIGHTS_LIST[state.PRIORITY_WEIGHT]
   # 2 points for rainbow supports, 1 point for normal supports, stat priority tie breaker
   rainbow_candidates = results
-
   for stat_name in rainbow_candidates:
+    multiplier = 1 + state.PRIORITY_EFFECTS_LIST[get_stat_priority(stat_name)] * priority_weight
     data = rainbow_candidates[stat_name]
     total_rainbow_friends = data[stat_name]["friendship_levels"]["yellow"] + data[stat_name]["friendship_levels"]["max"]
     #adding total rainbow friends on top of total supports for two times value nudging the formula towards more rainbows
     rainbow_points = total_rainbow_friends + data["total_supports"]
     if total_rainbow_friends > 0:
       rainbow_points = rainbow_points + 0.5
+    rainbow_points = rainbow_points * multiplier
     rainbow_candidates[stat_name]["rainbow_points"] = rainbow_points
     rainbow_candidates[stat_name]["total_rainbow_friends"] = total_rainbow_friends
 


### PR DESCRIPTION
This allows us to override some unwanted behaviors.

Example:
There's 1 rainbow support in speed but 3 non-rainbow supports in guts.
Currently total rainbow points for speed would be 2.5 and guts would be 3.
With some light weight adjustment the speed can go over the guts training if it's setup that way.

Also, when we have 2 non rainbow supports in speed and 1 rainbow support in guts for example, if the speed is weighted more than guts, the bot can pick speed instead of guts. (2 points vs 2.5 points before weight, if weights are 1 vs -1 the bot would pick speed in the new version).

This is pretty much a preference thing for now, after we can make custom strategies and varied modes of training, this will probably be unused.