### PR TITLE
Y-Offset Function to Fix Black Bars on Android Devices

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,6 +63,7 @@ def focus_umamusume():
   if bot.use_adb:
     info("Using ADB no need to focus window.")
     constants.adjust_constants_x_coords(offset=-155)
+    constants.adjust_constants_y_coords(offset=57)
     return True
   try:
     win = gw.getWindowsWithTitle("Umamusume")

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -174,6 +174,7 @@ RACE_BUTTON_IN_RACE_BBOX_LANDSCAPE=(800, 950, 1150, 1050)
 RACE_BUTTON_IN_RACE_REGION_LANDSCAPE = convert_xyxy_to_xywh(RACE_BUTTON_IN_RACE_BBOX_LANDSCAPE)
 SCENARIO_NAME = ""
 OFFSET_APPLIED = False
+OFFSET_Y_APPLIED = False
 def adjust_constants_x_coords(offset=405):
   """Shift all region tuples' x-coordinates by `offset`."""
 
@@ -222,6 +223,56 @@ def adjust_constants_x_coords(offset=405):
 
   update_training_button_positions()
   OFFSET_APPLIED = True
+
+def adjust_constants_y_coords(offset=0):
+  """Shift all region tuples' y-coordinates by `offset`."""
+
+  global OFFSET_Y_APPLIED
+  if OFFSET_Y_APPLIED:
+    return
+
+  g = globals()
+  for name, value in list(g.items()):
+    if (
+      name.endswith("_REGION")
+      and isinstance(value, tuple)
+      and len(value) == 4
+    ):
+      new_value = (
+        value[0],
+        value[1] + offset,
+        value[2],
+        value[3],
+      )
+      g[name] = tuple(x for x in new_value if x is not None)
+
+    if (
+      name.endswith("_MOUSE_POS")
+      and isinstance(value, tuple)
+      and len(value) == 2
+    ):
+      new_value = (
+        value[0],
+        value[1] + offset,
+      )
+      g[name] = tuple(x for x in new_value if x is not None)
+
+    if (
+      name.endswith("_BBOX")
+      and isinstance(value, tuple)
+      and len(value) == 4
+    ):
+      new_value = (
+        value[0],
+        value[1] + offset,
+        value[2],
+        value[3] + offset,
+      )
+      g[name] = tuple(x for x in new_value if x is not None)
+
+  update_training_button_positions()
+  OFFSET_Y_APPLIED = True
+
 
 TIMELINE = [
   "Junior Year Pre-Debut",


### PR DESCRIPTION
As discussed on Discord, this function adds an Y-Offset, but requires some extra commands on adb to ensure the device screen size stays on the recommended size (800x1080).

After connecting your device through ADB, run `adb shell wm size 800x1137` to adjust your device's screen size.

The Top Bar should take 57 pixels from the top and this should be the Y-Offset value, however I'm not good with Python so the offset variable is hardcoded in main.py, which would affect users without black bars at the top of the screen.