### PR TITLE
Speed and energy optimizations

### DIFF
--- a/core/actions.py
+++ b/core/actions.py
@@ -265,7 +265,7 @@ def start_race():
   if config.POSITION_SELECTION_ENABLED:
     select_position()
     sleep(0.5)
-  device_action.locate_and_click("assets/buttons/view_results.png", min_search_time=get_secs(10), region_ltrb=constants.SCREEN_BOTTOM_BBOX)
+  device_action.locate_and_click("assets/buttons/view_results.png", min_search_time=get_secs(20), region_ltrb=constants.SCREEN_BOTTOM_BBOX)
   sleep(0.5)
 
   close_btn = device_action.locate("assets/buttons/close_btn.png", min_search_time=get_secs(1))

--- a/core/skeleton.py
+++ b/core/skeleton.py
@@ -222,6 +222,7 @@ def career_lobby(dry_run_turn=False):
         action["is_race_day"] = True
         action["year"] = state_obj["year"]
         info(f"Race Day")
+        buy_skill(state_obj, action_count, race_check=True)
         if action.run():
           record_and_finalize_turn(state_obj, action)
           continue
@@ -288,7 +289,9 @@ def career_lobby(dry_run_turn=False):
             continue
           else:
             action.func = None
-
+      if strategy.at_stat_cap(state_obj):
+        state_obj['at_stat_cap'] = True
+        debug('at_stat_cap toggled')
       training_function_name = strategy.get_training_template(state_obj)['training_function']
 
       state_obj = collect_training_state(state_obj, training_function_name)

--- a/core/skill.py
+++ b/core/skill.py
@@ -20,17 +20,28 @@ def init_skill_py():
 
 def buy_skill(state, action_count, race_check=False):
   global previous_action_count
-  debug(f"Skill buy: {action_count}, {previous_action_count}, {race_check}")
-  if (config.IS_AUTO_BUY_SKILL and state["current_stats"]["sp"] >= config.SKILL_PTS_CHECK):
-    pass
-  else:
-    return False
-  if config.CHECK_SKILL_BEFORE_RACES and race_check and (action_count > previous_action_count):
-    debug(f"Passed race check condition.")
-    pass
-  elif (action_count - previous_action_count) < config.SKILL_CHECK_TURNS:
-    info("Hasn't been enough turns since last skill buy. Not trying.")
-    return False
+
+  if not(config.IS_AUTO_BUY_SKILL):  
+      debug(f"Not enough autobuyskill. {state["current_stats"]["sp"]} < {config.SKILL_PTS_CHECK}")
+
+      return
+  point_check = state["current_stats"]["sp"] >= config.SKILL_PTS_CHECK
+  race_turn_check = not(config.CHECK_SKILL_BEFORE_RACES) or race_check
+  first_skill_buy_since_bot_restarted = previous_action_count == -1
+  turn_count_check =  (action_count > previous_action_count) and (action_count - previous_action_count) >= config.SKILL_CHECK_TURNS
+  if not(point_check):
+      debug(f"Not enough points. {state["current_stats"]["sp"]} < {config.SKILL_PTS_CHECK}")
+      return False
+  if not(race_turn_check):
+      debug(f"Skip skill buy. No race this turn.")
+      return False
+  if first_skill_buy_since_bot_restarted:
+      debug(f"First skill buy since bot restarted.")
+      pass
+  elif not(turn_count_check):    
+      info("Skip skill buy. Hasn't been enough turns since last skill buy.")
+      return False
+  debug(f"Skill buy: {action_count}, {previous_action_count}, {race_check}, {first_skill_buy_since_bot_restarted}")
 
   previous_action_count = action_count
   device_action.locate_and_click("assets/buttons/skills_btn.png", min_search_time=get_secs(2))

--- a/core/state.py
+++ b/core/state.py
@@ -74,6 +74,9 @@ def collect_main_state():
 
 def collect_training_state(state_object, training_function_name):
   check_stat_gains = False
+  if state_object['energy_level'] < config.SKIP_TRAINING_ENERGY:
+    debug(f"Skip collecting training due to skip energy config. {int(state_object['energy_level'])} < {config.SKIP_TRAINING_ENERGY}")
+    return state_object
   if training_function_name == "meta_training" or training_function_name == "most_stat_gain":
     check_stat_gains = True
 

--- a/core/strategies.py
+++ b/core/strategies.py
@@ -178,6 +178,8 @@ class Strategy:
     current_energy = state['energy_level']
     criteria = state["criteria"]
     date_available = state['date_event_available']
+    mood_near_max = True if state["current_mood"] in ["GREAT", 'UNKNOWN', 'GOOD'] else False
+    mood_increasable = True if state["current_mood"] not in ["GREAT", 'UNKNOWN'] else False
     if 'URA Finale Finals' in criteria:
       # Always take wit training or recreation over resting on last turn.
       return action
@@ -185,11 +187,11 @@ class Strategy:
       return action
     if current_energy > config.NEVER_REST_ENERGY:
       return action
-    if current_energy <= 10 and not(action.func):
+    if current_energy <= 10:
       # Can't do much with low energy
       action.func = 'do_rest'
       return action
-    if state['date_event_available'] and self.get_mood_diff(state) < 0:
+    if current_energy <= 68 and date_available and not mood_near_max:
       # If you prefer something like racing over resting, put it as higher priority in the action sequence.
       # Ignore the mood-only tazuna event for now.
       action.func = 'do_recreation'
@@ -197,7 +199,7 @@ class Strategy:
     
     if not date_available:
       action.available_actions.append('do_rest')
-    elif current_energy >= 38:
+    elif current_energy >= 38 and not(mood_increasable):
       action.available_actions.extend(['do_recreation', 'do_rest'])
     else:      
       action.available_actions.extend(['do_rest', 'do_recreation'])

--- a/core/strategies.py
+++ b/core/strategies.py
@@ -199,7 +199,7 @@ class Strategy:
     
     if not date_available:
       action.available_actions.append('do_rest')
-    elif current_energy >= 38 and not(mood_increasable):
+    elif current_energy >= 38 and mood_increasable:
       action.available_actions.extend(['do_recreation', 'do_rest'])
     else:      
       action.available_actions.extend(['do_rest', 'do_recreation'])
@@ -467,9 +467,9 @@ class Strategy:
   def at_stat_cap(self, state):
     debug(f"check at_stat_cap logic")
     training_template = self.get_training_template(state)
-    for stat_name, stat_cap_value in training_template["target_stat_set"].items():
-      if state["current_stats"][stat_name] < stat_cap_value:
-        debug(f"not at stat cap because {stat_name} {state["current_stats"][stat_name]} < {stat_cap_value} ")
+    for stat_name, _ in training_template["target_stat_set"].items():
+      if state["current_stats"][stat_name] < config.STAT_CAPS[stat_name]:
+        debug(f"not at stat cap because {stat_name} {state["current_stats"][stat_name]} < {config.STAT_CAPS[stat_name]} ")
         return False
     debug("at_stat_cap should be toggled, lets check")
     return True

--- a/core/strategies.py
+++ b/core/strategies.py
@@ -133,46 +133,19 @@ class Strategy:
     info(f"Evaluating action sequence: {action_sequence}")
 
     for name in action_sequence:
-      if name == "rest":
-        action.available_actions.append("do_rest")
-        continue
       function_name = getattr(self, f"check_{name}")
+      if action.func:
+        break
       if name == "training":
         action = function_name(state, action, training_type, training_template)
       else:
         action = function_name(state, action)
 
-    if not action.func:
-      debug("No action selected, using priority fallback")
-      current_energy = state["energy_level"]
-      if current_energy > config.NEVER_REST_ENERGY:
-        remove_if_exists(action.available_actions, ["do_recreation", "do_infirmary", "do_rest"])
-        if len(action.available_actions) == 0:
-          action.func = "no_action"
-        else:
-          action.func = action.available_actions[0]
-        debug(f"High energy fallback: {action.func}")
-      elif current_energy < config.SKIP_TRAINING_ENERGY:
-        if state["date_event_available"]:
-          action.func = "do_recreation"
-          action.available_actions.append("do_recreation")
-        else:
-          action.func = "do_rest"
-          action.available_actions.append("do_rest")
-        
-        debug("Low energy: forcing rest")
-      elif current_energy < 50:
-        action.available_actions.append("do_rest")
-        if len(action.available_actions) == 0:
-          action.func = "do_rest"
-        else:
-          action.func = action.available_actions[0]
-      else:
-        if len(action.available_actions) == 0:
-          action.func = "no_action"
-        else:
-          action.func = action.available_actions[0]
-        debug(f"Normal energy fallback: {action.func}")
+    if action.func and len(action.available_actions) == 0:
+      action.available_actions.append(action.func)
+    elif not action.func and len(action.available_actions) > 0:
+      debug(f'Get highest priority from sequence list: {action.available_actions}')
+      action.func = action.available_actions[0]
 
     return action
 
@@ -201,20 +174,52 @@ class Strategy:
 
     return action
 
+  def check_rest(self, state, action):
+    current_energy = state['energy_level']
+    criteria = state["criteria"]
+    date_available = state['date_event_available']
+    if 'URA Finale Finals' in criteria:
+      # Always take wit training or recreation over resting on last turn.
+      return action
+    if 'URA Finale Semifinal' in criteria and current_energy >= 90:
+      return action
+    if current_energy > config.NEVER_REST_ENERGY:
+      return action
+    if current_energy <= 10 and not(action.func):
+      # Can't do much with low energy
+      action.func = 'do_rest'
+      return action
+    if state['date_event_available'] and self.get_mood_diff(state) < 0:
+      # If you prefer something like racing over resting, put it as higher priority in the action sequence.
+      # Ignore the mood-only tazuna event for now.
+      action.func = 'do_recreation'
+      return action
+    
+    if not date_available:
+      action.available_actions.append('do_rest')
+    elif current_energy >= 38:
+      action.available_actions.extend(['do_recreation', 'do_rest'])
+    else:      
+      action.available_actions.extend(['do_rest', 'do_recreation'])
+    return action
+
   def check_recreation(self, state, action):
     action["can_mood_increase"] = False
-    if "Junior Year" in state["year"]:
-      mood_difference = state["mood_difference_junior_year"]
-    else:
-      mood_difference = state["mood_difference"]
-    if mood_difference < 0:
+    mood_diff = self.get_mood_diff(state)
+    if mood_diff < 0:
       action.available_actions.append("do_recreation")
       action["can_mood_increase"] = True
       # mood increase required setting the function to do_recreation
-      if not action.func:
-        action.func = "do_recreation"
-      info(f"Recreation needed due to mood difference: {state['mood_difference']}")
-    elif state["current_mood"] != "GREAT" and state["current_mood"] != "UNKNOWN":
+      action.func = "do_recreation"
+      info(f"Recreation needed due to mood difference: {mood_diff}")
+      return action
+
+    if state['energy_level'] > config.NEVER_REST_ENERGY:
+      return action
+    if state['date_event_available'] and action["can_mood_increase"] and action['max_energy'] - action['energy_level'] > 30:
+      action.func = "do_recreation"
+      return action
+    if state["current_mood"] != "GREAT" and state["current_mood"] != "UNKNOWN":
       info(f"Recreation available. Current mood: {state['current_mood']} != GREAT and UNKNOWN")
       action["can_mood_increase"] = True
       action.available_actions.append("do_recreation")
@@ -226,6 +231,13 @@ class Strategy:
 
   # Check only unscheduled races
   def check_race(self, state, action, grades: list[str] = None):
+    if len(action.available_actions) == 0:
+      pass
+    elif len(action.available_actions) == 1 and action.available_actions[0] == 'do_training' and state.get('at_stat_cap', False):
+      pass
+    else:
+      # Never do an unscheduled race if other higher priority actions are queued up.
+      return action
     date = state["year"]
     if grades is not None:
       races_on_date = [r for r in constants.RACES[date] if r.get("grade") in grades]
@@ -251,10 +263,10 @@ class Strategy:
           best_fans_gained = fans_gained
 
     if best_race_name:
-      action.available_actions.append("do_race")
       action["race_name"] = best_race_name
       info(f"Unscheduled race found: {best_race_name}")
-      return action
+      action.func = 'do_race'
+    return action
 
   def check_scheduled_races(self, state, action):
     date = state["year"]
@@ -450,6 +462,16 @@ class Strategy:
 
     return action
 
+  def at_stat_cap(self, state):
+    debug(f"check at_stat_cap logic")
+    training_template = self.get_training_template(state)
+    for stat_name, stat_cap_value in training_template["target_stat_set"].items():
+      if state["current_stats"][stat_name] < stat_cap_value:
+        debug(f"not at stat cap because {stat_name} {state["current_stats"][stat_name]} < {stat_cap_value} ")
+        return False
+    debug("at_stat_cap should be toggled, lets check")
+    return True
+
   def validate_state(self, state):
     if state["year"] == "":
       return False
@@ -460,3 +482,9 @@ class Strategy:
     if state["criteria"] == "":
       return False
     return True
+
+  def get_mood_diff(self, state):
+    if "Junior Year" in state["year"]:
+      return state["mood_difference_junior_year"]
+    else:
+      return state["mood_difference"]

--- a/core/trainings.py
+++ b/core/trainings.py
@@ -309,6 +309,7 @@ def calculate_risk_increase(training_name, training_data, risk_taking_set):
 
 def filter_safe_trainings(state, training_template, use_risk_taking=False, check_stat_caps=False):
   if check_stat_caps and state.get('at_stat_cap', False):
+    debug('SAMTEST we are actually at stat cap, going to disable')
     check_stat_caps = False
   training_results = state['training_results']
   current_stats = state['current_stats']

--- a/core/trainings.py
+++ b/core/trainings.py
@@ -308,6 +308,8 @@ def calculate_risk_increase(training_name, training_data, risk_taking_set):
 
 
 def filter_safe_trainings(state, training_template, use_risk_taking=False, check_stat_caps=False):
+  if check_stat_caps and state.get('at_stat_cap', False):
+    check_stat_caps = False
   training_results = state['training_results']
   current_stats = state['current_stats']
   risk_taking_set = training_template['risk_taking_set']


### PR DESCRIPTION
Just getting thoughts not proposing this yet

1) Add check_rest, which will do the date if mood if possible, and force rest if below 10 energy
2) Make it so if energy is below never train level, skip straight to rest or recreation or race (whichever is highest in your sequence list)
3) After hitting stat cap, do unscheduled races (need to check consecutive racing stuff still)
4) Change strategies so that if an option is deemd good enough, other's won't get evaluated
5) Bot will no longer try to buy skills if above the skill threshold unless sufficient turns have passed since the last check rather than sufficient turns have passed since the last buy. This is in case no more skills have been added.
6) Bot will only check for skill buys on race turns now of the the config is enabled. You either had to pass the enough turns check OR the race check before, now you must pass both checks. 