### PR TITLE
Fix: Main screen year OCR fallback when on 3+ consecutive races

### DIFF
--- a/core/state.py
+++ b/core/state.py
@@ -446,19 +446,13 @@ def get_current_year():
 
   if device_action.locate_and_click("assets/buttons/races_btn.png", min_search_time=get_secs(10), region_ltrb=constants.SCREEN_BOTTOM_BBOX):
     info(f"Couldn't match year text in main screen, checking alternative on the race screen.")
+    device_action.locate_and_click("assets/buttons/ok_btn.png", min_search_time=get_secs(2)) # Consecutive races popup check
     device_action.locate("assets/buttons/back_btn.png", min_search_time=get_secs(2), region_ltrb=constants.SCREEN_BOTTOM_BBOX)
-
-    # If we are on a 3rd consecutive race, this menu will pop up.
-    consecutive_cancel_btn = device_action.locate("assets/buttons/cancel_btn.png", min_search_time=get_secs(1))
-    if consecutive_cancel_btn:
-      device_action.locate_and_click("assets/buttons/ok_btn.png", min_search_time=get_secs(1))
-      # Re-search for back button after entering race screen to allow for page load
-      device_action.locate("assets/buttons/back_btn.png", min_search_time=get_secs(2), region_ltrb=constants.SCREEN_BOTTOM_BBOX)
-      
     year_region = enhanced_screenshot(constants.RACE_LIST_YEAR_REGION)
     text = extract_text(year_region, allowlist=constants.OCR_DATE_RECOGNITION_SET)
     debug(f"Year text from races screen: {text}")
     device_action.locate_and_click("assets/buttons/back_btn.png", min_search_time=get_secs(2), region_ltrb=constants.SCREEN_BOTTOM_BBOX)
+    sleep(1)
 
   return text
 

--- a/core/state.py
+++ b/core/state.py
@@ -447,6 +447,14 @@ def get_current_year():
   if device_action.locate_and_click("assets/buttons/races_btn.png", min_search_time=get_secs(10), region_ltrb=constants.SCREEN_BOTTOM_BBOX):
     info(f"Couldn't match year text in main screen, checking alternative on the race screen.")
     device_action.locate("assets/buttons/back_btn.png", min_search_time=get_secs(2), region_ltrb=constants.SCREEN_BOTTOM_BBOX)
+
+    # If we are on a 3rd consecutive race, this menu will pop up.
+    consecutive_cancel_btn = device_action.locate("assets/buttons/cancel_btn.png", min_search_time=get_secs(1))
+    if consecutive_cancel_btn:
+      device_action.locate_and_click("assets/buttons/ok_btn.png", min_search_time=get_secs(1))
+      # Re-search for back button after entering race screen to allow for page load
+      device_action.locate("assets/buttons/back_btn.png", min_search_time=get_secs(2), region_ltrb=constants.SCREEN_BOTTOM_BBOX)
+      
     year_region = enhanced_screenshot(constants.RACE_LIST_YEAR_REGION)
     text = extract_text(year_region, allowlist=constants.OCR_DATE_RECOGNITION_SET)
     debug(f"Year text from races screen: {text}")


### PR DESCRIPTION
Added consideration if we are on 3+ consecutive races for when main screen OCR fails and we fallback to checking the race screen