### PR TITLE
Add webhook notifications for skill purchases

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -6,6 +6,7 @@ SLEEP_TIME_MULTIPLIER = 1
 
 WEBHOOK_URL = ""
 WEBHOOK_PROGRESS_ENABLED = True
+WEBHOOK_SKILL_BUY_ENABLED = True
 
 # to see any config variables you must call reload_config()
 def load_config():

--- a/server/main.py
+++ b/server/main.py
@@ -97,6 +97,7 @@ def update_setup_config(new_setup_config: dict):
 def update_webhook(data: dict):
   config.WEBHOOK_URL = data.get("webhook_url", "")
   config.WEBHOOK_PROGRESS_ENABLED = data.get("webhook_progress_enabled", True)
+  config.WEBHOOK_SKILL_BUY_ENABLED = data.get("webhook_skill_buy_enabled", True)
   return {"status": "success"}
 
 @app.get("/config/applied-preset")

--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -56,4 +56,6 @@ def reset_progress_tracking():
 def on_skills_bought(skills: list[str]):
     if not _webhook_enabled():
         return
+    if not getattr(config, "WEBHOOK_SKILL_BUY_ENABLED", True):
+        return
     webhook.send_skills_bought(skills)

--- a/web/src/components/set-up/WebhookSettings.tsx
+++ b/web/src/components/set-up/WebhookSettings.tsx
@@ -5,6 +5,7 @@ import Tooltips from "@/components/_c/Tooltips";
 
 const WEBHOOK_STORAGE_KEY = "webhook_url";
 const PROGRESS_STORAGE_KEY = "webhook_progress_enabled";
+const SKILL_BUY_STORAGE_KEY = "webhook_skill_buy_enabled";
 
 function readStoredUrl(): string {
   return localStorage.getItem(WEBHOOK_STORAGE_KEY) || "";
@@ -14,39 +15,51 @@ function readStoredProgress(): boolean {
   return localStorage.getItem(PROGRESS_STORAGE_KEY) !== "false";
 }
 
-function syncToServer(url: string, progress: boolean) {
+function readStoredSkillBuy(): boolean {
+  return localStorage.getItem(SKILL_BUY_STORAGE_KEY) !== "false";
+}
+
+function syncToServer(url: string, progress: boolean, skillBuy: boolean) {
   fetch("/api/webhook", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ webhook_url: url, webhook_progress_enabled: progress }),
+    body: JSON.stringify({ webhook_url: url, webhook_progress_enabled: progress, webhook_skill_buy_enabled: skillBuy }),
   }).catch(console.error);
 }
 
-function persistAndSync(url: string, progress: boolean) {
+function persistAndSync(url: string, progress: boolean, skillBuy: boolean) {
   localStorage.setItem(WEBHOOK_STORAGE_KEY, url);
   localStorage.setItem(PROGRESS_STORAGE_KEY, progress.toString());
-  syncToServer(url, progress);
+  localStorage.setItem(SKILL_BUY_STORAGE_KEY, skillBuy.toString());
+  syncToServer(url, progress, skillBuy);
 }
 
 export default function WebhookSettings() {
   const [webhookUrl, setWebhookUrl] = useState(readStoredUrl);
   const [progressEnabled, setProgressEnabled] = useState(readStoredProgress);
+  const [skillBuyEnabled, setSkillBuyEnabled] = useState(readStoredSkillBuy);
   const hasSynced = useRef(false);
 
   useEffect(() => {
     if (hasSynced.current) return;
     hasSynced.current = true;
-    syncToServer(readStoredUrl(), readStoredProgress());
+    syncToServer(readStoredUrl(), readStoredProgress(), readStoredSkillBuy());
   }, []);
 
   const commitUrl = () => {
-    persistAndSync(webhookUrl, progressEnabled);
+    persistAndSync(webhookUrl, progressEnabled, skillBuyEnabled);
   };
 
   const toggleProgress = () => {
     const next = !progressEnabled;
     setProgressEnabled(next);
-    persistAndSync(webhookUrl, next);
+    persistAndSync(webhookUrl, next, skillBuyEnabled);
+  };
+
+  const toggleSkillBuy = () => {
+    const next = !skillBuyEnabled;
+    setSkillBuyEnabled(next);
+    persistAndSync(webhookUrl, progressEnabled, next);
   };
 
   const hasWebhook = !!webhookUrl.trim();
@@ -76,6 +89,17 @@ export default function WebhookSettings() {
         <span className="font-base">Yearly Progress Updates</span>
         <Tooltips>
           Sends a stat snapshot at the start of Classic Year, Senior Year, and URA Finals.
+        </Tooltips>
+      </label>
+      <label className={`uma-label ${hasWebhook ? "" : "disabled"}`}>
+        <Checkbox
+          checked={skillBuyEnabled}
+          disabled={!hasWebhook}
+          onCheckedChange={toggleSkillBuy}
+        />
+        <span className="font-base">Skill Buy Notifications</span>
+        <Tooltips>
+          Sends a notification listing the skills purchased each time the bot buys skills.
         </Tooltips>
       </label>
     </>


### PR DESCRIPTION
## Summary
This PR adds a new webhook notification feature that allows users to receive notifications when the bot purchases skills. A new toggle has been added to the webhook settings UI to enable/disable this feature independently from progress notifications.

## Key Changes
- **Frontend (WebhookSettings.tsx)**
  - Added `SKILL_BUY_STORAGE_KEY` constant for localStorage persistence
  - Added `readStoredSkillBuy()` function to retrieve the stored preference
  - Added `skillBuyEnabled` state and `toggleSkillBuy()` handler
  - Added new checkbox UI control for "Skill Buy Notifications" with tooltip
  - Updated all webhook sync functions to include the skill buy enabled flag

- **Backend Configuration (core/config.py)**
  - Added `WEBHOOK_SKILL_BUY_ENABLED` config variable (defaults to `True`)

- **Server API (server/main.py)**
  - Updated `update_webhook()` endpoint to handle the new `webhook_skill_buy_enabled` parameter

- **Notifications (utils/notifications.py)**
  - Added guard clause in `on_skills_bought()` to check if skill buy notifications are enabled before sending webhooks

## Implementation Details
- The feature follows the same pattern as the existing progress notifications toggle
- Settings are persisted to localStorage and synced to the server
- The skill buy notification toggle is disabled when no webhook URL is configured
- Defaults to enabled (`True`) to maintain backward compatibility

https://claude.ai/code/session_019EG9ESvLNt9cFVozh5Bchh